### PR TITLE
The staging compose target should be manual

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,6 +118,8 @@ services:
       timeout: 5s
       retries: 5
       start_period: 30s
+    profiles:
+      - manual
 
   # BDD Testing service
   test:


### PR DESCRIPTION
The staging target shoudl not automatically start when docker compose up is run.