### PR TITLE
Group Dependabot minor/patch updates per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,13 @@ updates:
       artifact-handling:
         patterns:
           - "actions/download-artifact"
-          - "actions/upload-artifact"      
+          - "actions/upload-artifact"
+      github-actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -21,33 +27,47 @@ updates:
     cooldown:
       default-days: 3
     allow:
-      - dependency-type: "all"      
+      - dependency-type: "all"
     ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
       # ts-node has no stable release compatible with TypeScript 7's
       # restructured package exports (require('typescript').sys is gone).
       # Remove once ts-node (or its replacement) supports TS 7.
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
     groups:
-      development-dependencies:
-        dependency-type: "development"
+      npm-minor-patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "docker"
-    directories: 
+    directories:
       - "**/*"
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 3
+    groups:
+      docker-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "pip"
-    directories: 
+    directories:
       - "**/*"
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 3
+    groups:
+      pip-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

- Adds a `minor+patch` group to each ecosystem (`github-actions`, `npm`, `docker`, `pip`) so those updates land as one consolidated PR per ecosystem instead of individual PRs.
- Removes the npm `ignore` rule that dropped all semver-patch updates outright — those now show up, grouped.
- Replaces the `development-dependencies` (dev-vs-prod) npm group with the minor/patch group, since the split we actually want is by update type, not dependency type.
- Major updates are intentionally left out of every group, so they keep arriving as individual PRs.
- Kept the `typescript` semver-major ignore as-is — that's a targeted ts-node/TypeScript 7 compatibility hold, unrelated to this grouping change.

Closes #452

## Test plan

- [x] Validated `.github/dependabot.yml` parses as valid YAML
- [ ] Confirm Dependabot picks up the new groups on its next weekly run (grouped PRs appear per ecosystem, majors still individual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)