### PR TITLE
Silence Bootstrap/self Sass deprecation warnings in webpack build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,26 @@ module.exports = {
                         }
                     }, {
                         // compiles Sass to CSS
-                        loader: 'sass-loader'
+                        loader: 'sass-loader',
+                        options: {
+                            sassOptions: {
+                                // Bootstrap's own SCSS still uses Sass features (global
+                                // color functions, legacy @import, if()) that Dart Sass
+                                // now warns about. We don't control that code, so silence
+                                // deprecations from dependencies while still surfacing any
+                                // from our own src/bundle.scss.
+                                // https://sass-lang.com/documentation/js-api/interfaces/options/#quietDeps
+                                quietDeps: true,
+                                // bundle.scss itself still uses @import to pull in Bootstrap
+                                // partials one-by-one (needed so $body-color/$enable-dark-mode
+                                // overrides land between imports, per Bootstrap's own 5.3 Sass
+                                // customization docs). Bootstrap hasn't migrated its partials to
+                                // @use yet, so there's no forward-compatible replacement to move
+                                // to today; revisit once Bootstrap's own scss does.
+                                // https://sass-lang.com/documentation/js-api/interfaces/options/#silenceDeprecations
+                                silenceDeprecations: ['import']
+                            }
+                        }
                     }
                 ]
             },


### PR DESCRIPTION
## Summary
- Fixes #140 — validated it's still live: `docker compose run --rm dist` on `master` currently prints 242 repetitive Sass deprecation warnings (24 total webpack warnings), all originating either inside Bootstrap 5.3.8's own SCSS (deprecated global color functions like `mix()`, deprecated `if()` syntax) or from our own `src/bundle.scss`'s `@import` statements (needed so `$body-color`/`$enable-dark-mode` overrides land correctly between Bootstrap partial imports — Bootstrap hasn't migrated its own partials to the `@use` module system yet, so there's no forward-compatible replacement available today).
- Adds `sassOptions: { quietDeps: true, silenceDeprecations: ['import'] }` to the `sass-loader` entry in `webpack.config.js`. This only changes which deprecation warnings get printed during the build — it does not touch any Sass variables, function calls, or selectors, so the compiled output is unaffected.

## Verification
- **Warning counts**: before 24 total webpack warnings (20 shown Sass warnings + "242 repetitive... omitted" + 3 pre-existing bundle-size warnings) → after 3 total (only the pre-existing, unrelated bundle-size warnings remain, 0 Sass-related).
- **Compiled output unaffected**: `dist/bundle.js` before vs. after is byte-identical (610006 bytes both) except for a single internal webpack module-ID integer, a harmless artifact of the module graph — no CSS/JS content changed.
- **Webpack smoke test** (mirrors the `Webpack Bundle Smoke Test` CI check that will run on this PR since it touches `webpack.config.js`): `npm run test:smoke:webpack` passes, 595.7 KB bundle, only the pre-existing bundle-size warnings.
- **Visual regression**: full-page Playwright screenshots of `/`, `/construction_guide.html`, and `/tags/arduino/` captured before vs. after — homepage and construction_guide are pixel-identical (only normal anti-aliasing jitter between renders); `/tags/arduino/` showed a content-ordering difference traced to missing `date:` frontmatter on 4 posts causing Eleventy to fall back to filesystem mtime, which differs between the two git worktrees used for testing — a pre-existing content/tooling quirk unrelated to this change.
- **Test suite**: `.github/scripts/validate-local-build.sh` on this branch — HTTP smoke checks 200 on all 3 pages, AVIF/WebP counts as expected, full BDD/Playwright suite: 5/5 scenarios, 24/24 steps passed.

## Test plan
- [x] Confirmed issue still reproduces on `master`
- [x] Applied fix, confirmed warnings gone
- [x] Confirmed compiled bundle output unchanged
- [x] Ran `npm run test:smoke:webpack` locally
- [x] Before/after visual screenshot comparison of key pages
- [x] Ran full local BDD/validate-local-build.sh suite — all passing
- [ ] CI green on this PR (webpack smoke test, build_site, staging_test, lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)